### PR TITLE
Add fallback for misconfigured worker pool name case

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,10 +120,10 @@ PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
 docker-buildx: ## Build and push docker image for the manager for cross-platform support
 	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile
 	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
-	- $(CONTAINER_TOOL) buildx create --name kyma-workloads-webhook-builder
-	$(CONTAINER_TOOL) buildx use kyma-workloads-webhook-builder
+	- $(CONTAINER_TOOL) buildx create --name kim-snatch-builder
+	$(CONTAINER_TOOL) buildx use kim-snatch-builder
 	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .
-	- $(CONTAINER_TOOL) buildx rm kyma-workloads-webhook-builder
+	- $(CONTAINER_TOOL) buildx rm kim-snatch-builder
 	rm Dockerfile.cross
 
 .PHONY: build-installer

--- a/PROJECT
+++ b/PROJECT
@@ -5,8 +5,8 @@
 domain: kyma-project.io
 layout:
 - go.kubebuilder.io/v4
-projectName: kyma-workloads-webhook
-repo: github.com/kyma-project/kyma-workloads-webhook
+projectName: kim-snatch-webhook
+repo: github.com/kyma-project/kim-snatch
 resources:
 - core: true
   group: core

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -215,14 +215,14 @@ func main() {
 		os.Exit(1)
 	}
 
-	defultPod := webhookcorev1.ApplyDefaults(kymaWorkerPoolName)
+	defaultPod := webhookcorev1.ApplyDefaults(kymaWorkerPoolName)
 	if len(nodeList.Items) == 0 {
 		logger.Error(err, "kyma worker pool does not exist, switching to fallback",
 			"workerPoolName", kymaWorkerPoolName)
-		defultPod = webhookcorev1.ApplyDefaultsFallback(kymaWorkerPoolName)
+		defaultPod = webhookcorev1.ApplyDefaultsFallback(kymaWorkerPoolName)
 	}
 
-	if err = webhookcorev1.SetupPodWebhookWithManager(mgr, defultPod); err != nil {
+	if err = webhookcorev1.SetupPodWebhookWithManager(mgr, defaultPod); err != nil {
 		logger.Error(err, "unable to create webhook", "webhook", "Pod")
 		os.Exit(1)
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -31,9 +31,9 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/retry"
 
-	"github.com/kyma-project/kyma-workloads-webhook/internal/webhook/callback"
-	webhook "github.com/kyma-project/kyma-workloads-webhook/internal/webhook/server"
-	webhookcorev1 "github.com/kyma-project/kyma-workloads-webhook/internal/webhook/v1"
+	"github.com/kyma-project/kim-snatch/internal/webhook/callback"
+	webhook "github.com/kyma-project/kim-snatch/internal/webhook/server"
+	webhookcorev1 "github.com/kyma-project/kim-snatch/internal/webhook/v1"
 	admissionregistration "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -153,7 +153,7 @@ func main() {
 				logger.Error(err, "unable to read certificate")
 				os.Exit(1)
 			}
-			logger.Info("certificate loaded", certificateAuthorityName, string(data))
+			logger.Info("certificate loaded")
 
 			updateCABundle := callback.BuildUpdateCABundle(
 				context.Background(),
@@ -217,8 +217,10 @@ func main() {
 
 	defaultPod := webhookcorev1.ApplyDefaults(kymaWorkerPoolName)
 	if len(nodeList.Items) == 0 {
-		logger.Error(err, "kyma worker pool does not exist, switching to fallback",
-			"workerPoolName", kymaWorkerPoolName)
+		errMsg := fmt.Sprintf("worker.gardener.cloud/pool=%s not exist, switching to fallback",
+			kymaWorkerPoolName)
+
+		logger.Error(errInvalidArgument, errMsg)
 		defaultPod = webhookcorev1.ApplyDefaultsFallback(kymaWorkerPoolName)
 	}
 

--- a/config/certmanager/issuer.yaml
+++ b/config/certmanager/issuer.yaml
@@ -2,7 +2,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    app.kubernetes.io/name: kyma-workloads-webhook
+    app.kubernetes.io/name: kim-snatch
     app.kubernetes.io/managed-by: kustomize
   name: kyma
   namespace: kyma-system

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -46,6 +46,12 @@ patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 - path: manager_webhook_patch.yaml
+- patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: --kyma-worker-pool-name=cpu-worker-0
+  target:
+    kind: Deployment
 
 replacements:
   - source:

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -56,7 +56,7 @@ patches:
 replacements:
   - source:
       kind: Deployment
-      fieldPath: metadata.name
+      fieldPath: metadata.namespace
     targets:
       - select:
           name: kyma

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -6,7 +6,7 @@ namespace: kyma-system
 # "wordpress" becomes "alices-wordpress".
 # Note that it should also match with the prefix (text before '-') of the namespace
 # field above.
-namePrefix: snatch-
+namePrefix: kim-snatch-
 
 # Labels to add to all resources and selectors.
 #labels:
@@ -16,7 +16,6 @@ namePrefix: snatch-
 
 resources:
 #- ../crd
-- ../manager
 - ../rbac
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
@@ -34,6 +33,7 @@ resources:
 # Only CR(s) which requires webhooks and are applied on namespaces labeled with 'webhooks: enabled' will
 # be able to communicate with the Webhook Server.
 #- ../network-policy
+- ../manager
 
 # Uncomment the patches line if you enable Metrics, and/or are using webhooks and cert-manager
 patches:
@@ -50,6 +50,18 @@ patches:
     - op: add
       path: /spec/template/spec/containers/0/args/-
       value: --kyma-worker-pool-name=cpu-worker-0
+  target:
+    kind: Deployment
+- patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: --webhook-cfg-name=kim-snatch-mutating-webhook-configuration
+  target:
+    kind: Deployment
+- patch: |-
+    - op: replace
+      path: /spec/template/spec/containers/0/imagePullPolicy
+      value: IfNotPresent
   target:
     kind: Deployment
 

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -49,7 +49,7 @@ patches:
 
 replacements:
   - source:
-      kind: Namespace
+      kind: Deployment
       fieldPath: metadata.name
     targets:
       - select:

--- a/config/default/manager_webhook_patch.yaml
+++ b/config/default/manager_webhook_patch.yaml
@@ -4,7 +4,7 @@ metadata:
   name: controller-manager
   namespace: system
   labels:
-    app.kubernetes.io/name: kyma-workloads-webhook
+    app.kubernetes.io/name: kim-snatch
     app.kubernetes.io/managed-by: kustomize
 spec:
   template:

--- a/config/default/metrics_service.yaml
+++ b/config/default/metrics_service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   labels:
     control-plane: controller-manager
-    app.kubernetes.io/name: kyma-workloads-webhook
+    app.kubernetes.io/name: kim-snatch
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager-metrics-service
   namespace: system
@@ -15,3 +15,4 @@ spec:
     targetPort: 8443
   selector:
     control-plane: controller-manager
+    app.kubernetes.io/component: kim-snatch

--- a/config/gardener/certmanager/certificate.yaml
+++ b/config/gardener/certmanager/certificate.yaml
@@ -2,15 +2,16 @@ apiVersion: cert.gardener.cloud/v1alpha1
 kind: Certificate
 metadata:
   labels:
-    app.kubernetes.io/created-by: kyma-workloads-webhook
-    app.kubernetes.io/part-of: kyma-workloads-webhook
+    app.kubernetes.io/created-by: kim-snatch
+    app.kubernetes.io/part-of: kim-snatch
     app.kubernetes.io/managed-by: kustomize
   name: kyma
   namespace: system
 spec:
   commonName: snatch-webhook-service.kyma-system
   dnsNames:
-  - snatch-webhook-service.kyma-system.svc
+  - kim-snatch-webhook-service.kyma-system.svc
+  - kim-snatch-webhook-service.kyma-system.svc.cluster.local
   isCA: true
   issuerRef:
     name: kyma

--- a/config/gardener/certmanager/issuer.yaml
+++ b/config/gardener/certmanager/issuer.yaml
@@ -2,7 +2,7 @@ apiVersion: cert.gardener.cloud/v1alpha1
 kind: Issuer
 metadata:
   labels:
-    app.kubernetes.io/name: kyma-workloads-webhook
+    app.kubernetes.io/name: kim-snatch
     app.kubernetes.io/managed-by: kustomize
   name: kyma
   namespace: system

--- a/config/k3d/kustomization.yaml
+++ b/config/k3d/kustomization.yaml
@@ -12,13 +12,25 @@ patches:
       value: --kyma-worker-pool-name=snatch-test
   target:
     kind: Deployment
+- patch: |-
+    - op: replace
+      path: /spec/template/spec/containers/0/imagePullPolicy
+      value: Never
+  target:
+    kind: Deployment
+- patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: --webhook-cfg-name=snatch-mutating-webhook-configuration
+  target:
+    kind: Deployment
 
 resources:
-- ../manager
 - ../rbac
 - ../webhook
 - metrics_service.yaml
 - ../certmanager
+- ../manager
 
 sortOptions:
   order: fifo

--- a/config/k3d/manager_webhook_patch.yaml
+++ b/config/k3d/manager_webhook_patch.yaml
@@ -4,7 +4,7 @@ metadata:
   name: controller-manager
   namespace: system
   labels:
-    app.kubernetes.io/name: kyma-workloads-webhook
+    app.kubernetes.io/name: kim-snatch
     app.kubernetes.io/managed-by: kustomize
 spec:
   template:

--- a/config/k3d/metrics_service.yaml
+++ b/config/k3d/metrics_service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   labels:
     control-plane: controller-manager
-    app.kubernetes.io/name: kyma-workloads-webhook
+    app.kubernetes.io/name: kim-snatch
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager-metrics-service
   namespace: system

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,8 +4,8 @@ resources:
 - manager.yaml
 images:
 - name: controller
-  newName: snatch
-  newTag: local
+  newName: ttl.sh/snatch7
+  newTag: 1h
 - name: controller-admission
   newName: IMG=admission-testme
   newTag: latest

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -5,8 +5,9 @@ metadata:
   namespace: system
   labels:
     control-plane: controller-manager
-    app.kubernetes.io/name: kyma-workloads-webhook
+    app.kubernetes.io/name: kim-snatch-webhook
     app.kubernetes.io/managed-by: kustomize
+    sidecar.istio.io/inject: "false"
 spec:
   selector:
     matchLabels:
@@ -18,6 +19,8 @@ spec:
         kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: controller-manager
+        app.kubernetes.io/component: kim-snatch
+        sidecar.istio.io/inject: "false"
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
       # according to the platforms which are supported by your solution.
@@ -53,7 +56,6 @@ spec:
         - /manager
         args:
           - --health-probe-bind-address=:8081
-          - --webhook-cfg-name=snatch-mutating-webhook-configuration
         image: controller:latest
         # TODO(dev): Remove this
         imagePullPolicy: Never

--- a/config/network-policy/allow-metrics-traffic.yaml
+++ b/config/network-policy/allow-metrics-traffic.yaml
@@ -5,7 +5,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   labels:
-    app.kubernetes.io/name: kyma-workloads-webhook
+    app.kubernetes.io/name: kim-snatch
     app.kubernetes.io/managed-by: kustomize
   name: allow-metrics-traffic
   namespace: system

--- a/config/network-policy/allow-webhook-traffic.yaml
+++ b/config/network-policy/allow-webhook-traffic.yaml
@@ -5,7 +5,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   labels:
-    app.kubernetes.io/name: kyma-workloads-webhook
+    app.kubernetes.io/name: kim-snatch
     app.kubernetes.io/managed-by: kustomize
   name: allow-webhook-traffic
   namespace: system

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -4,7 +4,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     control-plane: controller-manager
-    app.kubernetes.io/name: kyma-workloads-webhook
+    app.kubernetes.io/name: kim-snatch
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager-metrics-monitor
   namespace: system

--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    app.kubernetes.io/name: kyma-workloads-webhook
+    app.kubernetes.io/name: kim-snatch
     app.kubernetes.io/managed-by: kustomize
   name: leader-election-role
 rules:

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    app.kubernetes.io/name: kyma-workloads-webhook
+    app.kubernetes.io/name: kim-snatch
     app.kubernetes.io/managed-by: kustomize
   name: leader-election-rolebinding
 roleRef:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -5,6 +5,12 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list
+- apiGroups:
   - admissionregistration.k8s.io
   resources:
   - mutatingwebhookconfigurations

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app.kubernetes.io/name: kyma-workloads-webhook
+    app.kubernetes.io/name: kim-snatch
     app.kubernetes.io/managed-by: kustomize
   name: manager-rolebinding
 roleRef:

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/name: kyma-workloads-webhook
+    app.kubernetes.io/name: kim-snatch
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager
   namespace: system

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -11,6 +11,6 @@ patches:
         path: /webhooks/0/namespaceSelector
         value:
           matchLabels:
-              managed-by: kyma
+              kyma-project.io/managed-by: kyma
     target:
       kind: MutatingWebhookConfiguration

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -11,6 +11,6 @@ patches:
         path: /webhooks/0/namespaceSelector
         value:
           matchLabels:
-              kyma-project.io/managed-by: kyma
+            operator.kyma-project.io/managed-by: kyma
     target:
       kind: MutatingWebhookConfiguration

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -12,7 +12,9 @@ webhooks:
       namespace: system
       path: /mutate--v1-pod
   failurePolicy: Ignore
+  matchPolicy: Exact
   name: mpod-v1.kb.io
+  reinvocationPolicy: Never
   rules:
   - apiGroups:
     - ""
@@ -20,7 +22,6 @@ webhooks:
     - v1
     operations:
     - CREATE
-    - UPDATE
     resources:
     - pods
   sideEffects: None

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/name: kyma-workloads-webhook
+    app.kubernetes.io/name: webhook-service
     app.kubernetes.io/managed-by: kustomize
   name: webhook-service
   namespace: system
@@ -13,3 +13,4 @@ spec:
       targetPort: 9443
   selector:
     control-plane: controller-manager
+    app.kubernetes.io/component: kim-snatch

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kyma-project/kyma-workloads-webhook
+module github.com/kyma-project/kim-snatch
 
 go 1.23.0
 

--- a/internal/webhook/callback/callback_test.go
+++ b/internal/webhook/callback/callback_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/kyma-project/kyma-workloads-webhook/internal/webhook/callback"
+	"github.com/kyma-project/kim-snatch/internal/webhook/callback"
 	"github.com/stretchr/testify/assert"
 	admissionregistration "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/internal/webhook/server/server.go
+++ b/internal/webhook/server/server.go
@@ -29,9 +29,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/kyma-project/kyma-workloads-webhook/internal/httpserver"
-	logf "github.com/kyma-project/kyma-workloads-webhook/internal/log"
-	"github.com/kyma-project/kyma-workloads-webhook/internal/metrics"
+	"github.com/kyma-project/kim-snatch/internal/httpserver"
+	logf "github.com/kyma-project/kim-snatch/internal/log"
+	"github.com/kyma-project/kim-snatch/internal/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"

--- a/internal/webhook/v1/pod_webhook.go
+++ b/internal/webhook/v1/pod_webhook.go
@@ -35,23 +35,24 @@ const (
 // log is for logging in this package.
 var podlog = logf.Log.WithName("pod-resource")
 
+type defaultPod = func(*corev1.Pod)
+
 // SetupPodWebhookWithManager registers the webhook for Pod in the manager.
-func SetupPodWebhookWithManager(mgr ctrl.Manager, nodeSelectorValue string) error {
+func SetupPodWebhookWithManager(mgr ctrl.Manager, defdefaultPod defaultPod) error {
 	return ctrl.NewWebhookManagedBy(mgr).For(&corev1.Pod{}).
-		WithDefaulter(&PodCustomDefaulter{
-			nodeSelectorValue: nodeSelectorValue,
-		}).
+		WithDefaulter(&PodCustomDefaulter{defaultPod: defdefaultPod}).
 		Complete()
 }
 
 // +kubebuilder:webhook:path=/mutate--v1-pod,mutating=true,failurePolicy=ignore,sideEffects=None,groups="",resources=pods,verbs=create;update,versions=v1,name=mpod-v1.kb.io,admissionReviewVersions=v1
 
+//+kubebuilder:rbac:groups="",resources=nodes,verbs=list
 //+kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations,verbs=get;patch
 
 // PodCustomDefaulter struct is responsible for setting default values on the custom resource of the
 // Kind Pod when those are created or updated.
 type PodCustomDefaulter struct {
-	nodeSelectorValue string
+	defaultPod func(*corev1.Pod)
 }
 
 var _ webhook.CustomDefaulter = &PodCustomDefaulter{}
@@ -65,14 +66,31 @@ func (d *PodCustomDefaulter) Default(ctx context.Context, obj runtime.Object) er
 	}
 
 	podlog.Info("Defaulting for Pod", "name", pod.GetName(), "ns", pod.GetNamespace())
-	d.applyDefaults(pod)
+	d.defaultPod(pod)
 	return nil
 }
 
-func (d *PodCustomDefaulter) applyDefaults(pod *corev1.Pod) {
-	if pod.Spec.NodeSelector == nil {
-		pod.Spec.NodeSelector = map[string]string{}
-	}
+func ApplyDefaults(nodeSelectorValue string) defaultPod {
+	return func(pod *corev1.Pod) {
+		if pod.Spec.NodeSelector == nil {
+			pod.Spec.NodeSelector = map[string]string{}
+		}
 
-	pod.Spec.NodeSelector[kymaNodeSelectorKey] = d.nodeSelectorValue
+		pod.Spec.NodeSelector[kymaNodeSelectorKey] = nodeSelectorValue
+	}
+}
+
+var ErrNodeNotFound = fmt.Errorf("node selector not found")
+
+func ApplyDefaultsFallback(nodeSelectorValue string) defaultPod {
+	return func(pod *corev1.Pod) {
+		if pod.Annotations == nil {
+			pod.Annotations = map[string]string{}
+		}
+
+		pod.Annotations[kymaNodeSelectorKey] = nodeSelectorValue
+		podlog.Error(ErrNodeNotFound, "unable to set node selector",
+			"node-selector-value", nodeSelectorValue,
+		)
+	}
 }

--- a/internal/webhook/v1/webhook_suite_test.go
+++ b/internal/webhook/v1/webhook_suite_test.go
@@ -119,7 +119,7 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 
-	err = SetupPodWebhookWithManager(mgr, testNodeKymaLabelValue)
+	err = SetupPodWebhookWithManager(mgr, ApplyDefaults(testNodeKymaLabelValue))
 	Expect(err).NotTo(HaveOccurred())
 
 	// +kubebuilder:scaffold:webhook

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -25,7 +25,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/kyma-project/kyma-workloads-webhook/test/utils"
+	"github.com/kyma-project/kim-snatch/test/utils"
 )
 
 var (
@@ -52,7 +52,7 @@ var (
 // CertManager and Prometheus.
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
-	_, _ = fmt.Fprintf(GinkgoWriter, "Starting kyma-workloads-webhook integration test suite\n")
+	_, _ = fmt.Fprintf(GinkgoWriter, "Starting kim-snatch integration test suite\n")
 	RunSpecs(t, "e2e suite")
 }
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Manager", Ordered, func() {
 		Expect(err).NotTo(HaveOccurred(), "Failed to create namespace")
 
 		By("labeling kyma-system namespace")
-		cmd = exec.Command("kubectl", "label", "namespace", namespace, "managed-by=kyma")
+		cmd = exec.Command("kubectl", "label", "namespace", namespace, "kyma-project.io/managed-by=kyma")
 		_, err = utils.Run(cmd)
 		Expect(err).NotTo(HaveOccurred(), "Failed to deploy the controller-manager")
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -27,7 +27,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/kyma-project/kyma-workloads-webhook/test/utils"
+	"github.com/kyma-project/kim-snatch/test/utils"
 )
 
 // namespace where the project is deployed in
@@ -40,7 +40,7 @@ const serviceAccountName = "snatch-controller-manager"
 const metricsServiceName = "snatch-controller-manager-metrics-service"
 
 // metricsRoleBindingName is the name of the RBAC that will be created to allow get the metrics data
-const metricsRoleBindingName = "kyma-workloads-webhook-metrics-binding"
+const metricsRoleBindingName = "kim-snatch-metrics-binding"
 
 // path to simple pod definition
 const simplePod = "./test/e2e/resources/simple-pod.yaml"
@@ -67,7 +67,7 @@ var _ = Describe("Manager", Ordered, func() {
 		Expect(err).NotTo(HaveOccurred(), "Failed to create namespace")
 
 		By("labeling kyma-system namespace")
-		cmd = exec.Command("kubectl", "label", "namespace", namespace, "kyma-project.io/managed-by=kyma")
+		cmd = exec.Command("kubectl", "label", "namespace", namespace, "operator.kyma-project.io/managed-by=kyma")
 		_, err = utils.Run(cmd)
 		Expect(err).NotTo(HaveOccurred(), "Failed to deploy the controller-manager")
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -356,7 +356,6 @@ var _ = Describe("Manager", Ordered, func() {
 			}
 			Eventually(deleteCertificate).Should(Succeed())
 
-			// NOTE add extra verification step once the implementation will be finished
 			By("verify webhook was triggered")
 			verifyWebhookTriggered := func(g Gomega) {
 				cmd := exec.Command("kubectl", "get", "pod", "pause", "-o", "go-template={{.spec.nodeSelector}}")


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- fallback for misconfigured worker pool name case added
- rename namespace selector to: `operator.kyma-project.io/managed-by=kyma`
- fix `defaultPod` variable typo 
- default overlay will use `worker.gardener.cloud/pool=cpu-worker-0`
- `k3d` overlay will use `pullPolicy=Never`, `default`  will use `pullPolicy: IfNotFound`
- `kim-snatch` will react only on pod creation

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/infrastructure-manager/issues/396