### PR TITLE
Switch node selectors to node affinity

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -61,6 +61,7 @@ var (
 	scheme             = runtime.NewScheme()
 	logger             = ctrl.Log.WithName("setup")
 	errInvalidArgument = fmt.Errorf("invalid argument")
+	omittedNamespaces  = []string{"kube-system"}
 )
 
 func init() {
@@ -215,7 +216,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	defaultPod := webhookcorev1.ApplyDefaults(kymaWorkerPoolName)
+	defaultPod := webhookcorev1.ApplyDefaults(kymaWorkerPoolName, omittedNamespaces)
 	if len(nodeList.Items) == 0 {
 		errMsg := fmt.Sprintf("worker.gardener.cloud/pool=%s not exist, switching to fallback",
 			kymaWorkerPoolName)

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
 - manager.yaml
 images:
 - name: controller
-  newName: ttl.sh/snatch7
+  newName: ttl.sh/snatch8
   newTag: 1h
 - name: controller-admission
   newName: IMG=admission-testme

--- a/internal/webhook/v1/webhook_suite_test.go
+++ b/internal/webhook/v1/webhook_suite_test.go
@@ -119,7 +119,7 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 
-	err = SetupPodWebhookWithManager(mgr, ApplyDefaults(testNodeKymaLabelValue))
+	err = SetupPodWebhookWithManager(mgr, ApplyDefaults(testNodeKymaLabelValue, []string{"kube-system"}))
 	Expect(err).NotTo(HaveOccurred())
 
 	// +kubebuilder:scaffold:webhook

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -338,10 +338,10 @@ var _ = Describe("Manager", Ordered, func() {
 
 			By("verify webhook was triggered")
 			verifyWebhookTriggered := func(g Gomega) {
-				cmd := exec.Command("kubectl", "get", "pod", "-n", namespace, "pause", "-o", "go-template={{.spec.nodeSelector}}")
+				cmd := exec.Command("kubectl", "get", "pod", "-n", namespace, "pause", "-o", "go-template={{.spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution}}")
 				output, err := utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred())
-				expected := fmt.Sprintf("worker.gardener.cloud/pool:%s", testNodeKymaLabelValue)
+				expected := fmt.Sprintf("key:worker.gardener.cloud/pool operator:In values:[%s]", testNodeKymaLabelValue)
 				g.Expect(output).To(ContainSubstring(expected))
 			}
 			Eventually(verifyWebhookTriggered).Should(Succeed())
@@ -358,7 +358,7 @@ var _ = Describe("Manager", Ordered, func() {
 
 			By("verify webhook was triggered")
 			verifyWebhookTriggered := func(g Gomega) {
-				cmd := exec.Command("kubectl", "get", "pod", "pause", "-o", "go-template={{.spec.nodeSelector}}")
+				cmd := exec.Command("kubectl", "get", "pod", "pause", "-o", "go-template={{.spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution}}")
 				output, err := utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(output).To(Equal("<no value>"))


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- `kim-snatch` injects node affinity instead of node selector in labeled namespaces
- improved webhook logging messages 
- pods creation calls in `kube-system` namespace are now omitted from being intercepted 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
