### PR TITLE
Limit Cipher Suites to TLS 1.3

### DIFF
--- a/internal/webhook/server/server.go
+++ b/internal/webhook/server/server.go
@@ -169,7 +169,7 @@ func (s *DefaultServer) Start(ctx context.Context) error {
 
 	cfg := &tls.Config{ //nolint:gosec
 		NextProtos: []string{"h2"},
-		CipherSuites: []uint16{
+		CipherSuites: []uint16{ //limited to TLS 1.3, see https://pkg.go.dev/crypto/tls
 			tls.TLS_AES_128_GCM_SHA256,
 			tls.TLS_AES_256_GCM_SHA384,
 			tls.TLS_CHACHA20_POLY1305_SHA256,

--- a/internal/webhook/server/server.go
+++ b/internal/webhook/server/server.go
@@ -169,6 +169,11 @@ func (s *DefaultServer) Start(ctx context.Context) error {
 
 	cfg := &tls.Config{ //nolint:gosec
 		NextProtos: []string{"h2"},
+		CipherSuites: []uint16{
+			tls.TLS_AES_128_GCM_SHA256,
+			tls.TLS_AES_256_GCM_SHA384,
+			tls.TLS_CHACHA20_POLY1305_SHA256,
+		},
 	}
 	// fallback TLS config ready, will now mutate if passer wants full control over it
 	for _, op := range s.Options.TLSOpts {

--- a/internal/webhook/server/server.go
+++ b/internal/webhook/server/server.go
@@ -169,12 +169,9 @@ func (s *DefaultServer) Start(ctx context.Context) error {
 
 	cfg := &tls.Config{ //nolint:gosec
 		NextProtos: []string{"h2"},
-		CipherSuites: []uint16{ //limited to TLS 1.3, see https://pkg.go.dev/crypto/tls
-			tls.TLS_AES_128_GCM_SHA256,
-			tls.TLS_AES_256_GCM_SHA384,
-			tls.TLS_CHACHA20_POLY1305_SHA256,
-		},
+		MinVersion: tls.VersionTLS13,
 	}
+
 	// fallback TLS config ready, will now mutate if passer wants full control over it
 	for _, op := range s.Options.TLSOpts {
 		op(cfg)


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Limit Cipher Suites supported by webhook to TLS 1.3 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
