### PR TITLE
Adding type RegistryCacheConfig to the list of types processed by kustomize

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -3,6 +3,7 @@
 # It should be run by config/default
 resources:
 - bases/core.kyma-project.io_customconfigs.yaml
+- bases/core.kyma-project.io_registrycacheconfigs.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
 patches:

--- a/config/samples/core_v1beta1_registrycacheconfig.yaml
+++ b/config/samples/core_v1beta1_registrycacheconfig.yaml
@@ -1,0 +1,9 @@
+apiVersion: core.kyma-project.io/v1beta1
+kind: RegistryCacheConfig
+metadata:
+  labels:
+    app.kubernetes.io/name: kim-snatch-webhook
+    app.kubernetes.io/managed-by: kustomize
+  name: registrycacheconfig-sample
+spec:
+  # TODO(user): Add fields here


### PR DESCRIPTION
Small fix to add `RegistryCacheConfig` to the list of types processed by kustomize