### PR TITLE
Update sec-scanners-config.yaml to latest

### DIFF
--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -1,7 +1,7 @@
 module-name: kim-snatch
 kind: kyma
 bdba:
-  - europe-docker.pkg.dev/kyma-project/prod/kim-snatch:1.0.8-experimental
+  - europe-docker.pkg.dev/kyma-project/prod/kim-snatch:latest
 mend:
   language: golang-mod
   exclude:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

@Sawthis let us know that we:

> On the main branch, you should use the newest images that you use on the development branch, usually main. You can check if you have new CVEs in the introduced code before the release

This PR aims to adjust to that guidance.

**Related issue(s)**