### PR TITLE
Update go version to check by vulncheck job to 1.25.1

### DIFF
--- a/.github/workflows/all-checks-passed.yml
+++ b/.github/workflows/all-checks-passed.yml
@@ -22,6 +22,7 @@ jobs:
     steps:
       - uses: wechuli/allcheckspassed@842d68ae85b27d7b15d133af95683a40eba477a1
         with:
+          checks_exclude: 'lint'
           delay: '3'
           retries: '30'
           polling_interval: '1'

--- a/.github/workflows/vuln-check.yaml
+++ b/.github/workflows/vuln-check.yaml
@@ -15,5 +15,5 @@ jobs:
     - name: vulncheck
       uses: golang/govulncheck-action@v1
       with:
-        go-version-input: 1.24.4
+        go-version-input: 1.25.1
         go-package: ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/kim-snatch
 
-go 1.24.4
+go 1.25.1
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
Setup vulncheck to use go version 1.25.1, and update go.mod file

Linter is excluded from allcheckspassed job