### PR TITLE
golang 1.25 linter fix

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,4 +35,4 @@ jobs:
       - name: Run linter
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          version: v2.1.2
+          version: v2.5.0


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- fixes linter issue where old version did not support golang 1.25
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
