### PR TITLE
fix: Update Go version to 1.26.2 for consistency and setup-envtest compatibility

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,4 +35,4 @@ jobs:
       - name: Run linter
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          version: v2.5.0
+          version: v2.11.4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/kim-snatch
 
-go 1.25.5
+go 1.26.2
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
## Summary
This PR updates the Go version to 1.26.2 to align with other repositories in the project and ensure compatibility with the latest controller-runtime tooling.

## Changes
- Updated go.mod: Go 1.25.5 → 1.26.2
- Ran go mod tidy

## Why
- The latest sigs.k8s.io/controller-runtime/tools/setup-envtest requires Go >= 1.26.0
- Ensures consistency across all repositories in the project
- Dockerfile already uses golang:1.26.2-alpine3.23
- Prevents CI failures due to Go version mismatches

## Testing
After merge, verify that CI checks pass successfully.