### PR TITLE
Add gate job in workflows with pull_request_target

### DIFF
--- a/.github/workflows/build_snatch.yml
+++ b/.github/workflows/build_snatch.yml
@@ -82,17 +82,14 @@ jobs:
   summary:
     runs-on: ubuntu-latest
     needs: [build-image]
-    if: always() && contains(needs.*.result, 'success')
+    if: needs.build-image.result == 'success'
     steps:
       - name: "Generate summary"
         run: |
           {
             echo '# kim-snatch'
-            # if build-image was successful
-            if [ "${{ needs.build-image.result }}" == "success" ]; then
-              printf '\n\n## Image\n'
-              printf '\n```json\n'
-              echo '${{ needs.build-image.outputs.images }}' | jq
-              printf '\n```\n'
-            fi
+            printf '\n\n## Image\n'
+            printf '\n```json\n'
+            echo '${{ needs.build-image.outputs.images }}' | jq
+            printf '\n```\n'
           } >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build_snatch.yml
+++ b/.github/workflows/build_snatch.yml
@@ -29,7 +29,19 @@ permissions:
   contents: read # This is required for actions/checkout
 
 jobs:
+  gate:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      github.event.pull_request.head.repo.full_name != github.repository
+    environment: ${{ vars.PROTECTED_ENVIRONMENT }}
+    steps:
+      - name: Approve fork PR image build
+        run: echo "Image build approved for fork PR"
+
   setup:
+    needs: [gate]
+    if: ${{ !cancelled() && (needs.gate.result == 'success' || needs.gate.result == 'skipped') }}
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -40,9 +52,9 @@ jobs:
       latest: ${{ steps.latest.outputs.latest || '' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - id: tag
         if: github.event_name == 'push' && github.ref_type == 'tag'
@@ -53,7 +65,10 @@ jobs:
 
   build-image:
     name: run-image-builder
-    needs: setup
+    needs: [setup, gate]
+    if: >-
+      needs.setup.result == 'success' &&
+      (needs.gate.result == 'success' || needs.gate.result == 'skipped')
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     with:
       name: kim-snatch
@@ -67,7 +82,7 @@ jobs:
   summary:
     runs-on: ubuntu-latest
     needs: [build-image]
-    if: success() || failure()
+    if: always() && contains(needs.*.result, 'success')
     steps:
       - name: "Generate summary"
         run: |

--- a/.github/workflows/daily-markdown-link-check.yaml
+++ b/.github/workflows/daily-markdown-link-check.yaml
@@ -8,7 +8,7 @@ jobs:
   daily-markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: gaurav-nelson/github-action-markdown-link-check@0524e79d8d7d1606112722dd7a3b5f5ce367de3e
         with:
           use-quiet-mode: 'yes'  

--- a/.github/workflows/lint-markdown-links.yml
+++ b/.github/workflows/lint-markdown-links.yml
@@ -5,7 +5,7 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: gaurav-nelson/github-action-markdown-link-check@0524e79d8d7d1606112722dd7a3b5f5ce367de3e
         with:
           use-verbose-mode: 'no'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go
         uses: actions/setup-go@v5

--- a/.github/workflows/pull-gitleaks.yml
+++ b/.github/workflows/pull-gitleaks.yml
@@ -10,7 +10,7 @@ jobs:
   scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Fetch gitleaks ${{ env.GITLEAKS_VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       contents: write  # Needed for creating releases and uploading assets
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Go
         uses: actions/setup-go@v6

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone the code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup Go
         uses: actions/setup-go@v6
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go
         uses: actions/setup-go@v5

--- a/.github/workflows/vuln-check.yaml
+++ b/.github/workflows/vuln-check.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: vulncheck
       uses: golang/govulncheck-action@v1

--- a/.github/workflows/vuln-check.yaml
+++ b/.github/workflows/vuln-check.yaml
@@ -9,9 +9,6 @@ jobs:
   govuln:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
-
     - name: vulncheck
       uses: golang/govulncheck-action@v1
       with:


### PR DESCRIPTION
# Add Gate Job for Fork PR Approval in Workflows

### New Feature

✨ Introduces a `gate` job in the `build_snatch` workflow to enforce a manual approval step before building images from fork pull requests. This prevents unauthorized code execution from external contributors by requiring a protected environment approval when a PR originates from a forked repository.

### Changes

* `.github/workflows/build_snatch.yml`:
  - Added a new `gate` job that runs only when a `pull_request_target` event comes from a fork (i.e., `head.repo.full_name != github.repository`), requiring approval via a protected environment.
  - Updated `setup` and `build-image` jobs to depend on `gate`, proceeding only if `gate` succeeded or was skipped (non-fork PRs).
  - Changed `summary` job condition from `success() || failure()` to `always() && contains(needs.*.result, 'success')` to ensure it only runs when at least one job succeeded.
  - Fixed checkout `ref` to use `pull_request.head.sha` instead of `pull_request.head.ref` for safer SHA-pinned checkouts.
  - Bumped `actions/checkout` from `v4` to `v6`.

* `.github/workflows/daily-markdown-link-check.yaml`: Bumped `actions/checkout` from `v4` to `v6`.

* `.github/workflows/lint-markdown-links.yml`: Bumped `actions/checkout` from `v4` to `v6`.

* `.github/workflows/lint.yml`: Bumped `actions/checkout` from `v4` to `v6`.

* `.github/workflows/pull-gitleaks.yml`: Bumped `actions/checkout` from `v4` to `v6`.

* `.github/workflows/release.yml`: Bumped `actions/checkout` from `v5` to `v6`.

* `.github/workflows/tests.yml`: Bumped `actions/checkout` from `v4`/`v5` to `v6` across both `controller-tests` and `e2e-tests` jobs.

* `.github/workflows/vuln-check.yaml`: Bumped `actions/checkout` from `v4` to `v6`.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.47`

- Correlation ID: `fb29f2bc-f9b1-4420-847c-b9bd0a04ab04`
- Event Trigger: `pull_request.opened`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- LLM: `anthropic--claude-4.6-sonnet`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- File Content Strategy: Full file content
</details>
