### PR TITLE
Fix build-image gate condition: require approval for all PRs, fix skip propagation

### DIFF
--- a/.github/workflows/build_snatch.yml
+++ b/.github/workflows/build_snatch.yml
@@ -31,9 +31,7 @@ permissions:
 jobs:
   gate:
     runs-on: ubuntu-latest
-    if: >-
-      github.event_name == 'pull_request_target' &&
-      github.event.pull_request.head.repo.full_name != github.repository
+    if: github.event_name == 'pull_request_target'
     environment: ${{ vars.PROTECTED_ENVIRONMENT }}
     steps:
       - name: Approve fork PR image build
@@ -66,9 +64,7 @@ jobs:
   build-image:
     name: run-image-builder
     needs: [setup, gate]
-    if: >-
-      needs.setup.result == 'success' &&
-      (needs.gate.result == 'success' || needs.gate.result == 'skipped')
+    if: ${{ !cancelled() && needs.setup.result == 'success' && (needs.gate.result == 'success' || needs.gate.result == 'skipped') }}
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     with:
       name: kim-snatch


### PR DESCRIPTION
## Problem

PR #342 introduced the `gate` job but left two issues:

1. **`gate` only applied to fork PRs** — upstream branch PRs (Renovate, team members) bypassed the gate entirely, skipping the image build.
2. **`build-image` used bare `>-` YAML syntax for its `if` condition** — GitHub Actions has a known behaviour where reusable workflow jobs (`uses:`) with a skipped job in `needs` are automatically skipped when the `if` is not wrapped in `${{ }}`, regardless of the condition's logic.

Combined, these caused `run-image-builder` to be skipped for every tag push and every upstream branch PR.

## Fix

**Change 1 — `gate` job:** Remove the `head.repo.full_name != github.repository` restriction so all `pull_request_target` events require manual approval, not just fork PRs.

**Change 2 — `build-image` job:** Wrap the `if` condition in `${{ !cancelled() && ... }}` to match the same pattern already used on `setup`, preventing GitHub from short-circuiting the reusable workflow job when `gate` is skipped.

## Behaviour after fix

| Trigger | `gate` | `build-image` |
|---|---|---|
| Tag push | skipped | builds automatically |
| Push to `main` | skipped | builds automatically |
| Upstream branch PR (Renovate, team) | waits for approval | builds after approval |
| Fork PR (external contributor) | waits for approval | builds after approval |

## Test plan
- [ ] Open an upstream branch PR and verify `gate` pauses for approval
- [ ] Approve and verify `run-image-builder` runs
- [ ] Push a tag and verify image builds automatically without approval