### PR TITLE
Skip manual build approval gate for renovate PRs

### DIFF
--- a/.github/workflows/build_snatch.yml
+++ b/.github/workflows/build_snatch.yml
@@ -31,7 +31,7 @@ permissions:
 jobs:
   gate:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request_target'
+    if: github.event_name == 'pull_request_target' && github.actor != 'renovate[bot]'
     environment: ${{ vars.PROTECTED_ENVIRONMENT }}
     steps:
       - name: Approve fork PR image build


### PR DESCRIPTION
## Summary

- Adds an exception to the `gate` job so that PRs from `renovate[bot]` skip the protected environment approval
- Renovate PRs use same-repo branches (not forks), so they don't carry the untrusted-code risk the gate was designed to prevent
- Downstream jobs already handle a skipped gate via `needs.gate.result == 'skipped'`, so no further changes are needed

## Security note

The `github.actor` value for `renovate[bot]` uses the `[bot]` suffix which is reserved by GitHub for GitHub Apps — it cannot be spoofed by a regular user account.

## Test plan

- [ ] Open a renovate PR and verify the `gate` job is skipped and the build proceeds without manual approval
- [ ] Open a fork PR and verify the `gate` job still requires approval as before

Propagated from kyma-project/kyma-infrastructure-manager#1475