### PR TITLE
Add component-config.yaml

### DIFF
--- a/component-config.yaml
+++ b/component-config.yaml
@@ -1,0 +1,4 @@
+name: kyma-project.io/kyma-runtime/kyma-components/kim-snatch
+team: kyma/framefrog
+images:
+  - europe-docker.pkg.dev/kyma-project/prod/kim-snatch:latest


### PR DESCRIPTION
## Summary

This PR adds a `component-config.yaml` file at the repository root, listing the images produced by the kim-snatch module.

- Defines the component name as `kyma-project.io/kyma-runtime/kyma-components/kim-snatch`
- Associates the component with the `kyma/framefrog` team
- Lists the image `europe-docker.pkg.dev/kyma-project/prod/kim-snatch:latest`

This follows the same pattern established by infrastructure-manager and other Kyma components for consistent component configuration across repositories.